### PR TITLE
FIX: Updated Cooking Lab url params

### DIFF
--- a/src/components/getRecipe.tsx
+++ b/src/components/getRecipe.tsx
@@ -30,7 +30,7 @@ const GetRecipe = () => {
       let url = `${targetEndpoint}/api/recipes?cuisineType=${cuisineType}&mealType=${mealType}`;
   
       if(mealType === 'desserts'){
-        url = `${targetEndpoint}/api/recipes?cuisineType=${cuisineType}&mealType=dinner&dishType=desserts`;
+        url = `${targetEndpoint}/api/recipes?cuisineType=${cuisineType}&dishType=desserts`;
       }
 
       if (diet.length > 0) {


### PR DESCRIPTION
Updated the api call to clear the mealType when selecting desserts.

Screenshot:
![image](https://github.com/user-attachments/assets/cf0d21d5-3ef3-43ec-862f-11db082b3fde)
