### PR TITLE
OPT (#54): Modified personal recipe endpoint for id

### DIFF
--- a/src/components/getPersonalRecipe.tsx
+++ b/src/components/getPersonalRecipe.tsx
@@ -24,7 +24,7 @@ const GetPersonalRecipe = () => {
 
   async function handlePersonalRecipeClick() {
     try {
-      const response = await axios.get(`${targetEndpoint}/api/recipes/personal?id=${id}`);
+      const response = await axios.get(`${targetEndpoint}/api/recipes/personal/${id}`);
       const data = response.data;
       setRecipe({id: data[0].id, title: data[0].title, ingredients: data[0].ingredients, instructions: data[0].instructions, imageURL: data[0].imageURL});
       return data;

--- a/src/components/test/getPersonalRecipe.test.tsx
+++ b/src/components/test/getPersonalRecipe.test.tsx
@@ -48,7 +48,7 @@ describe('GetPersonalRecipe Component', () => {
     );
   
     await waitFor(() => {
-      expect(axios.get).toHaveBeenCalledWith('http://localhost:8080/api/recipes/personal?id=undefined');
+      expect(axios.get).toHaveBeenCalledWith('http://localhost:8080/api/recipes/personal/undefined');
     });
   });
   
@@ -67,7 +67,7 @@ describe('GetPersonalRecipe Component', () => {
   
     await waitFor(() => {
       expect(axios.get).toHaveBeenCalledWith(
-        'https://cooking-lab-personal-recipe-api.onrender.com/api/recipes/personal?id=1'
+        'https://cooking-lab-personal-recipe-api.onrender.com/api/recipes/personal/1'
       );
     });
   });


### PR DESCRIPTION
- Updated endpoint for id to `${targetEndpoint}/api/recipes/personal/${id}`
- Updated unit test for GetPersonalRecipe

Screenshot for UI getting recipe with id path:
<img width="1460" alt="Screenshot 2024-11-28 at 2 13 13 PM" src="https://github.com/user-attachments/assets/74e15ca9-6a6e-4cba-a31c-a51a75e603ac">

Screenshot for unit test coverage:
<img width="684" alt="Screenshot 2024-11-28 at 2 18 22 PM" src="https://github.com/user-attachments/assets/6418d797-663f-48d2-a313-21b4c134133b">
